### PR TITLE
Lower produces error when hostnames are uppercase

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1911,7 +1911,7 @@ class OpenShiftFacts(object):
         hostname_f = output.strip() if exit_code == 0 else ''
         hostname_values = [hostname_f, self.system_facts['ansible_nodename'],
                            self.system_facts['ansible_fqdn']]
-        hostname = choose_hostname(hostname_values, ip_addr).lower()
+        hostname = choose_hostname(hostname_values, ip_addr)
 
         defaults['common'] = dict(ip=ip_addr,
                                   public_ip=ip_addr,


### PR DESCRIPTION
This commits fixes the following issue.

Issue : 
When launching the control plane upgrade with uppercase hostnames, the following error is produced : 
"Confirm Reconcile Security Context Constraints will not change current SCCs"

This error is resulted by a wrong current-context in /etc/origin/master/openshift-master.kubeconfig file
This puts the master-api down.

Result : 
/!\ Current context hostname is lower case
current-context: default/xxxx-domaine-fr:8443/system:openshift-master
kind: Config
preferences: {}
users:
- name: system:openshift-master/XXXX-domaine-fr:8443

Expected : 
/!\ Current context hostname is uppercase
current-context: default/XXXX-domaine-fr:8443/system:openshift-master
kind: Config
preferences: {}
users:
- name: system:openshift-master/XXXX-domaine-fr:8443